### PR TITLE
Adding dunder eq to flow class. Uncommenting flow and pickle tests

### DIFF
--- a/src/canhydro/DataClasses.py
+++ b/src/canhydro/DataClasses.py
@@ -10,22 +10,31 @@ from shapely.geometry import Polygon
 @dataclass
 class Projection:
     plane: str
-    polygon: Polygon()
+    polygon: Polygon
     base_vector: list[int]
     anti_vector: list[int]
-    angle: int()
+    angle: int
 
 
 @dataclass
 class Flow:
-    num_cylinders: int()
-    projected_area: np.float64()
-    surface_area: np.float64()
-    angle_sum: np.float64()
-    volume: np.float64()
-    sa_to_vol: np.float64()
-    drip_node_id: int()
-    drip_node_loc: tuple()
+    num_cylinders: int
+    projected_area: np.float64
+    surface_area: np.float64
+    angle_sum: np.float64
+    volume: np.float64
+    sa_to_vol: np.float64
+    drip_node_id: int
+    drip_node_loc: tuple
+
+    def __eq__(self,flow:Flow):
+        return (np.round(self.num_cylinders, decimals=1) == np.round(flow.num_cylinders, decimals=1)
+                and np.round(self.projected_area, decimals=3)   == np.round(flow.projected_area, decimals=3)
+                and np.round(self.surface_area  , decimals=3)       == np.round(flow.surface_area, decimals=3)
+                and np.round(self.angle_sum     , decimals=3)       == np.round(flow.angle_sum, decimals=3)
+                and np.round(self.volume        , decimals=3)       == np.round(flow.volume, decimals=3)
+                and np.round(self.sa_to_vol     , decimals=3)       == np.round(flow.sa_to_vol, decimals=3))
+
 
 
 coord_list = Union[list[tuple[np.float64]], np.ndarray]

--- a/test/expected_results.py
+++ b/test/expected_results.py
@@ -1266,7 +1266,7 @@ ten_cyls_flows = [
         volume=0.327783,
         sa_to_vol=100.98563451833446,
         drip_node_id=0,
-        drip_node_loc=(0.076822, -3.386935),
+        drip_node_loc=(0.076822, -3.386935, -0.595933)
     )
 ]
 
@@ -1279,7 +1279,7 @@ happy_path_flows = [
         volume=0.5217939999999999,
         sa_to_vol=10791.467322627153,
         drip_node_id=0,
-        drip_node_loc=(0.076822, -3.386935),
+        drip_node_loc=(0.076822, -3.386935, -0.595933),
     ),
     Flow(
         num_cylinders=2,
@@ -2089,7 +2089,7 @@ drip_adj_flows = [
         volume=0.521757,
         sa_to_vol=4664.192277179154,
         drip_node_id=0,
-        drip_node_loc=(0.076822, -3.386935),
+        drip_node_loc=(0.076822, -3.386935, -0.595933),
     ),
     Flow(
         num_cylinders=9,

--- a/test/test_collection_integration.py
+++ b/test/test_collection_integration.py
@@ -215,50 +215,55 @@ def test_lam_filter(basic_collection, expected_result, lam_func):
     actual_result = [cyl.cyl_id for cyl in cyls_returned]
     assert actual_result == expected_result
 
+@pytest.mark.parametrize(
+    "basic_collection, expected_stem_map, expected_flows",
+    find_flows_cases,
+    indirect=["basic_collection"],
+)
+def test_find_flows(basic_collection, expected_stem_map, expected_flows):
+    basic_collection.project_cylinders("XY")
+    basic_collection.initialize_digraph_from()
+    basic_collection.find_flow_components()
+    basic_collection.calculate_flows()
+    actual_flows = basic_collection.flows
+    _, actual_stem_map = lam_filter(
+        basic_collection.cylinders, lambda: is_stem, return_all=True
+    )
+    print(actual_flows)
+    print(expected_flows)
+    try:
+        assert actual_flows == expected_flows
+        assert actual_stem_map == expected_stem_map
+    except AssertionError as e:
+        breakpoint()
+        raise e
 
-#****Only not passing due to differences in float arithmetic
-#       Manually confirmed to pass
-# @pytest.mark.parametrize(
-#     "basic_collection, expected_stem_map, expected_flows",
-#     find_flows_cases,
-#     indirect=["basic_collection"],
-# )
-# def test_find_flows(basic_collection, expected_stem_map, expected_flows):
-#     basic_collection.project_cylinders("XY")
-#     basic_collection.initialize_digraph_from()
-#     basic_collection.find_flow_components()
-#     basic_collection.calculate_flows()
-#     actual_flows = basic_collection.flows
-#     _, actual_stem_map = lam_filter(
-#         basic_collection.cylinders, lambda: is_stem, return_all=True
-#     )
-#     print(actual_flows)
-#     print(expected_flows)
-#     assert actual_flows == expected_flows
-#     assert actual_stem_map == expected_stem_map
 
+@pytest.mark.parametrize(
+    "basic_collection, expected_stem_map, expected_flows",
+    find_flows_cases,
+    indirect=["basic_collection"],
+)
+def test_pickle(basic_collection, expected_stem_map, expected_flows):
+    basic_collection.project_cylinders("XY")
+    basic_collection.initialize_digraph_from()
+    basic_collection.find_flow_components()
+    basic_collection.calculate_flows()
+    try:
+        pickle_file = pickle_collection(basic_collection)
+        unpickled_collection = unpickle_collection(pickle_file)
 
-
-# @pytest.mark.parametrize(
-#     "basic_collection, expected_stem_map, expected_flows",
-#     find_flows_cases,
-#     indirect=["basic_collection"],
-# )
-# def test_pickle(basic_collection, expected_stem_map, expected_flows):
-#     basic_collection.project_cylinders("XY")
-#     basic_collection.initialize_digraph_from()
-#     basic_collection.find_flow_components()
-#     pickle_file = pickle_collection(basic_collection)
-#     unpickled_collection = unpickle_collection(pickle_file)
-
-#     actual_flows = unpickled_collection.flows
-#     _, actual_stem_map = lam_filter(
-#         unpickled_collection.cylinders, lambda: is_stem, return_all=True
-#     )
-#     print(actual_flows)
-#     print(expected_flows)
-#     assert actual_flows == expected_flows
-#     assert actual_stem_map == expected_stem_map
+        actual_flows = unpickled_collection.flows
+        _, actual_stem_map = lam_filter(
+            unpickled_collection.cylinders, lambda: is_stem, return_all=True
+        )
+        print(actual_flows)
+        print(expected_flows)
+        assert actual_flows == expected_flows
+        assert actual_stem_map == expected_stem_map
+    except Exception as e:
+        breakpoint()
+        raise e
 
 
 @pytest.mark.parametrize("flexible_collection", ["1_TenCyls.csv"], indirect=True)


### PR DESCRIPTION
A previous change in the calculate_flows function converted to the use numpy. The fact that we are now using numpy floats rather than decimals caused some of our tests to erroneously fail. That is, the tests were successful on manual inspection, but showed as failed given differences in values < 0.00001.

In this PR, I've added a dunder __eq__ function to the flow class to assert equality if flow projected areas, volumes etc. match up to three decimal places. Given this solves the above issue, I've also commented the find_flows and pickle tests